### PR TITLE
REFACTOR : 함께 먹기 관련

### DIFF
--- a/src/main/java/com/dwu/alonealong/controller/TogetherOrderController.java
+++ b/src/main/java/com/dwu/alonealong/controller/TogetherOrderController.java
@@ -26,11 +26,6 @@ import com.dwu.alonealong.service.AloneAlongFacade;
 @Controller
 @SessionAttributes({"together"})
 public class TogetherOrderController {
-	public static final int GATHERING = 0;
-	public static final int GATHERED = 1;
-	public static final int IS_NOT_HOST = 0;
-	public static final int IS_HOST = 1;
-	
 	public static Order order;
 
 	private AloneAlongFacade aloneAlong;
@@ -123,13 +118,13 @@ public class TogetherOrderController {
 	}
 	
 	public void insertUserIntoMember(User user, Together together) {
-		TogetherMember togetherMember = new TogetherMember("TOGMEM_ID.NEXTVAL", user.getId(), together.getTogetherId(), IS_NOT_HOST);
+		TogetherMember togetherMember = new TogetherMember("TOGMEM_ID.NEXTVAL", user.getId(), together.getTogetherId(), TogetherMember.IS_NOT_HOST);
 		aloneAlong.insertTogetherMember(togetherMember);
 	}
 	
 	public void completeGathering(Together together) {
 		Together newTogether = new Together(together.getTogetherId(), together.getTogetherName(), together.getHeadCount(), together.getTogetherDate(), together.getTogetherTime(), 
-				together.getSex(), together.getAge(), together.getTogetherDes(), together.getResId(), GATHERED, together.getPrice());
+				together.getSex(), together.getAge(), together.getTogetherDes(), together.getResId(), Together.GATHERED, together.getPrice());
 		aloneAlong.updateTogether(newTogether);
 	}
 	

--- a/src/main/java/com/dwu/alonealong/controller/TogetherRegisterController.java
+++ b/src/main/java/com/dwu/alonealong/controller/TogetherRegisterController.java
@@ -35,10 +35,6 @@ import com.dwu.alonealong.service.AloneAlongFacade;
 @Controller
 @SessionAttributes({"retaurantList", "sessionFoodCart"})
 public class TogetherRegisterController {
-	public static final int GATHERING = 0;
-	public static final int GATHERED = 1;
-	public static final int IS_NOT_HOST = 0;
-	public static final int IS_HOST = 1;
 	
 	private AloneAlongFacade aloneAlong;
 	
@@ -115,7 +111,7 @@ public class TogetherRegisterController {
 			return "redirect:/togetherRegister";
 		
 		//together 넣기		
-		Together together = new Together("TOG_ID.NEXTVAL", name, headCount, date, time, sex, age, description, resId, GATHERING, cart.getSubTotal() / headCount);
+		Together together = new Together("TOG_ID.NEXTVAL", name, headCount, date, time, sex, age, description, resId, Together.GATHERING, cart.getSubTotal() / headCount);
 		aloneAlong.insertTogether(together);
 		
 		UserSession userSession = (UserSession)request.getSession().getAttribute("userSession");
@@ -161,7 +157,7 @@ public class TogetherRegisterController {
 	}
 	
 	public void insertHostIntoTogether(User user, Together together) {
-		TogetherMember togetherMember = new TogetherMember("TOGMEM_ID.NEXTVAL", user.getId(), together.getTogetherId(), IS_HOST);
+		TogetherMember togetherMember = new TogetherMember("TOGMEM_ID.NEXTVAL", user.getId(), together.getTogetherId(), TogetherMember.IS_HOST);
 		aloneAlong.insertTogetherMember(togetherMember);
 	}
 	

--- a/src/main/java/com/dwu/alonealong/controller/TogetherUpdateController.java
+++ b/src/main/java/com/dwu/alonealong/controller/TogetherUpdateController.java
@@ -29,8 +29,7 @@ import com.dwu.alonealong.service.AloneAlongFacade;
 @SessionAttributes({"sessionFoodCart"})
 @Controller
 public class TogetherUpdateController {
-	public static final int GATHERING = 0;
-	public static final int GATHERED = 1;
+	
 	
 	private AloneAlongFacade aloneAlong;
 	
@@ -129,7 +128,7 @@ public class TogetherUpdateController {
 		if(resId == null) return "redirect:/togetherUpdate/{togetherId}";
 		
 		//together 수정
-		Together newTogether = new Together(togId, name, headCount, date, time, sex, age, description, resId, GATHERING, cart.getSubTotal() / headCount);
+		Together newTogether = new Together(togId, name, headCount, date, time, sex, age, description, resId, Together.GATHERING, cart.getSubTotal() / headCount);
 		aloneAlong.updateTogether(newTogether);
 		
 		updateFoods(togId, cart, newTogether); //음식 수정

--- a/src/main/java/com/dwu/alonealong/domain/Together.java
+++ b/src/main/java/com/dwu/alonealong/domain/Together.java
@@ -9,6 +9,8 @@ import java.util.StringTokenizer;
 @SuppressWarnings("serial")
 public class Together implements Serializable {
 	public static final int MIN_HEAD_COUNT = 2;
+	public static final int GATHERING = 0;
+	public static final int GATHERED = 1;
 	
 	private String togetherId;
 	private String togetherName;

--- a/src/main/java/com/dwu/alonealong/domain/TogetherMember.java
+++ b/src/main/java/com/dwu/alonealong/domain/TogetherMember.java
@@ -4,7 +4,9 @@ import java.io.Serializable;
 
 @SuppressWarnings("serial")
 public class TogetherMember implements Serializable {
-
+	public static final int IS_NOT_HOST = 0;
+	public static final int IS_HOST = 1;
+	
 	private String togetherMemberId;
 	private String userId;
 	private String togetherId;


### PR DESCRIPTION
- 심볼릭 정수로 치환하는 부분 보완
컨트롤러 마다 추가했던 `GATHERING`, `GATHERED`, `IS_NOT_HOST`, `IS_HOST` 을 Together 클래스로 통합해 가져다 쓰도록 함

### 1. 클래스의 추출
해당 사항 없음

### 2. 타입 코드를 클래스로 치환
해당 사항 없음

**Together 클래스** : 함께 먹기 상태 `status`를 나타내는 `GATHERING = 0` `GATHERED = 1`
**TogetherMember 클래스** : 호스트 여부 `isHost`를 나타내는 `IS_NOT_HOST = 0`, `IS_HOST = 1`

-> 타입이 많은 것이 아니라 0과 1 두 개 뿐이라 따로 타입 코드 클래스를 추가할 필요가 없다고 생각함.

### 3. 타입 코드를 서브 클래스로 치환
위와 같은 이유로 해당 사항 없음

### 4. 타입 코드를 State/Strategy로 치환
위와 같은 이유로 해당 사항 없음

### 5. 오류 코드를 예외로 치환
에러를 처리하는 코드가 존재하지 않아서 해당 사항 없음